### PR TITLE
Add license information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,5 @@
+Google's Material Design Icons are released under the Apache License 2.0
+
+For further license information, check Google's official repo:
+
+https://github.com/google/material-design-icons/blob/master/LICENSE


### PR DESCRIPTION
Since this repo is a remix of Google's stuff, I expect the best thing to do is point back to the upstream license information.